### PR TITLE
Add arm64 architecture support to Docker builds

### DIFF
--- a/.github/workflows/build-release-docker-hub.yml
+++ b/.github/workflows/build-release-docker-hub.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.prep.outputs.tags }}
           labels: |


### PR DESCRIPTION
## Summary
- Enable multi-architecture Docker image builds by adding `linux/arm64` to the platforms list
- Images will now be built for both amd64 and arm64 architectures
- Allows native execution on ARM-based systems (e.g., Apple Silicon, AWS Graviton)

## Test plan
- [ ] Verify the workflow runs successfully on next release
- [ ] Confirm both amd64 and arm64 images are available on Docker Hub

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build pipeline to support multi-architecture container images. The build process now generates compatible Docker images for both standard Intel/AMD (amd64) and ARM64-based platforms, expanding deployment flexibility and hardware compatibility across different processor architectures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->