### PR TITLE
chore: add CLAUDE.md with workspace-context hint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,21 @@
+# CLAUDE.md
+
+> **Workspace context.** This repo is part of the Alkemio polyrepo at
+> [alkem-io/alkemio-workspace](https://github.com/alkem-io/alkemio-workspace).
+> Cross-repo (vertical) feature specs live there under `specs/NNN-*/`. When
+> working on a `feat/NNN-...` branch in this repo, the matching workspace
+> spec is the single source of truth.
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Repository Overview
+
+<!-- TODO: Brief description — what this service does, key technologies, where the main code lives. -->
+
+## Common Commands
+
+<!-- TODO: Most-used dev commands (build, run, test, lint). -->
+
+## Architecture
+
+<!-- TODO: Sketch architecture — entry points, key modules, external dependencies. -->


### PR DESCRIPTION
This repo currently has no `CLAUDE.md`. This PR adds a minimal stub so that:

1. Claude sessions opened in this repo have a starting point, AND
2. The workspace-context hint (linking to
   [`alkem-io/alkemio-workspace`](https://github.com/alkem-io/alkemio-workspace))
   is discoverable from this side too.

The body of the new file is a small set of `TODO` placeholders for repo
maintainers to fill in (Repository Overview, Common Commands, Architecture)
when they get a chance. Nothing else is changed.

Same wording is being added (as a 6-line blockquote) to every other active
Alkemio repo that already has a CLAUDE.md, via a parallel rollout.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>