### PR TITLE
feat(019): TypeScript 7 (native tsgo) upgrade

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -25,5 +25,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Typecheck (native)
+        run: pnpm run typecheck:native
+
       - name: Test
         run: pnpm run test

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,10 @@
 engine-strict=true
+
+# Resiliency for constrained/high-latency networks (e.g. Docker build
+# environments): lower parallel fetch pressure and allow more retries with a
+# longer per-request timeout instead of failing fast on a single flaky
+# socket. Defaults are network-concurrency=16, fetch-timeout=60000,
+# fetch-retries=2.
+network-concurrency=8
+fetch-timeout=120000
+fetch-retries=5

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM --platform=$BUILDPLATFORM node:22-slim AS build
 
 WORKDIR /usr/src/app
 
-COPY package.json pnpm-lock.yaml ./
+COPY package.json pnpm-lock.yaml .npmrc ./
 
 # Use pnpm with the lockfile to install all dependencies for building
 RUN corepack enable pnpm && pnpm install --frozen-lockfile

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -50,7 +50,7 @@ export default defineConfig([
     ignores: ['**/node_modules/**/*', '**/dist**'],
 
     rules: {
-      quotes: ['error', 'single'],
+      quotes: ['error', 'single', { avoidEscape: true }],
       'no-console': env(1, 0),
       'no-debugger': env(1, 0),
       '@typescript-eslint/interface-name-prefix': 'off',

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -20,6 +20,16 @@ const compat = new FlatCompat({
 const env = (prod, dev) => (process.env.NODE_ENV === 'production' ? prod : dev);
 
 export default defineConfig([
+  // Global ignores: a config object whose ONLY key is `ignores` applies to
+  // every config in the array (including the flat-compat-derived configs
+  // below), unlike the `ignores` nested in the ts/tsx config object which
+  // only scopes that one config. Without this, ESLint 9 flat-config mode
+  // (which no longer honors the CLI `--ext` flag) linted committed `dist/`
+  // build output with the compat-derived @typescript-eslint rules, which
+  // don't have the plugin registered for non-ts/tsx files.
+  {
+    ignores: ['**/node_modules/**', '**/dist/**'],
+  },
   {
     languageOptions: {
       parser: tsParser,
@@ -46,8 +56,6 @@ export default defineConfig([
       'plugin:prettier/recommended',
       'prettier'
     ),
-
-    ignores: ['**/node_modules/**/*', '**/dist**'],
 
     rules: {
       quotes: ['error', 'single', { avoidEscape: true }],

--- a/nest-cli.json
+++ b/nest-cli.json
@@ -4,7 +4,12 @@
   "sourceRoot": "src",
   "compilerOptions": {
     "deleteOutDir": true,
-    "builder": "swc",
+    "builder": {
+      "type": "swc",
+      "options": {
+        "stripLeadingPaths": true
+      }
+    },
     "typeCheck": true
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "start:dev": "nest start --watch",
     "test": "vitest run --config test/config/vitest.config.ts",
     "test:ui": "vitest --ui --config test/config/vitest.config.ts",
-    "test:coverage": "vitest run --coverage --config test/config/vitest.config.ts && open-cli coverage/index.html"
+    "test:coverage": "vitest run --coverage --config test/config/vitest.config.ts && open-cli coverage/index.html",
+    "typecheck:native": "tsc -p tsconfig.json --noEmit"
   },
   "keywords": [
     "collaboration",
@@ -66,6 +67,7 @@
     "@swc/cli": "^0.8.0",
     "@swc/core": "^1.13.5",
     "@types/node": "^22.18.1",
+    "@typescript/native": "npm:typescript@7.0.2",
     "@typescript-eslint/eslint-plugin": "^8.42.0",
     "@typescript-eslint/parser": "^8.42.0",
     "@vitest/coverage-v8": "3.2.7",
@@ -84,7 +86,7 @@
     "ts-loader": "^9.5.4",
     "tsconfig-paths": "^4.2.0",
     "tsx": "^4.20.5",
-    "typescript": "^5.9.2",
+    "typescript": "npm:@typescript/typescript6@6.0.2",
     "unplugin-swc": "^1.5.1",
     "vite": "5.4.21",
     "vite-tsconfig-paths": "5.1.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,16 +77,19 @@ importers:
         version: 22.20.0
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.42.0
-        version: 8.62.1(@typescript-eslint/parser@8.62.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3)
+        version: 8.62.1(@typescript-eslint/parser@8.62.1(@typescript/typescript6@6.0.2)(eslint@9.39.4))(@typescript/typescript6@6.0.2)(eslint@9.39.4)
       '@typescript-eslint/parser':
         specifier: ^8.42.0
-        version: 8.62.1(eslint@9.39.4)(typescript@5.9.3)
+        version: 8.62.1(@typescript/typescript6@6.0.2)(eslint@9.39.4)
+      '@typescript/native':
+        specifier: npm:typescript@7.0.2
+        version: typescript@7.0.2
       '@vitest/coverage-v8':
         specifier: 3.2.7
         version: 3.2.7(vitest@3.2.7)
       '@vitest/eslint-plugin':
         specifier: ^1.0.1
-        version: 1.6.21(@typescript-eslint/eslint-plugin@8.62.1(@typescript-eslint/parser@8.62.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3)(vitest@3.2.7)
+        version: 1.6.21(@typescript-eslint/eslint-plugin@8.62.1(@typescript-eslint/parser@8.62.1(@typescript/typescript6@6.0.2)(eslint@9.39.4))(@typescript/typescript6@6.0.2)(eslint@9.39.4))(@typescript/typescript6@6.0.2)(eslint@9.39.4)(vitest@3.2.7)
       '@vitest/ui':
         specifier: 3.2.7
         version: 3.2.7(vitest@3.2.7)
@@ -98,7 +101,7 @@ importers:
         version: 10.1.8(eslint@9.39.4)
       eslint-plugin-import:
         specifier: ^2.32.0
-        version: 2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)
+        version: 2.32.0(@typescript-eslint/parser@8.62.1(@typescript/typescript6@6.0.2)(eslint@9.39.4))(eslint@9.39.4)
       eslint-plugin-n:
         specifier: ^14.0.0
         version: 14.0.0(eslint@9.39.4)
@@ -122,7 +125,7 @@ importers:
         version: 6.1.3
       ts-loader:
         specifier: ^9.5.4
-        version: 9.6.2(typescript@5.9.3)(webpack@5.106.2(@swc/core@1.15.43))
+        version: 9.6.2(@typescript/typescript6@6.0.2)(webpack@5.106.2(@swc/core@1.15.43))
       tsconfig-paths:
         specifier: ^4.2.0
         version: 4.2.0
@@ -130,8 +133,8 @@ importers:
         specifier: ^4.20.5
         version: 4.23.0
       typescript:
-        specifier: ^5.9.2
-        version: 5.9.3
+        specifier: npm:@typescript/typescript6@6.0.2
+        version: '@typescript/typescript6@6.0.2'
       unplugin-swc:
         specifier: ^1.5.1
         version: 1.5.9(@swc/core@1.15.43)(rollup@4.62.0)
@@ -140,13 +143,13 @@ importers:
         version: 5.4.21(@types/node@22.20.0)(terser@5.48.0)
       vite-tsconfig-paths:
         specifier: 5.1.4
-        version: 5.1.4(typescript@5.9.3)(vite@5.4.21(@types/node@22.20.0)(terser@5.48.0))
+        version: 5.1.4(@typescript/typescript6@6.0.2)(vite@5.4.21(@types/node@22.20.0)(terser@5.48.0))
       vitest:
         specifier: ^3.2.4
         version: 3.2.7(@types/node@22.20.0)(@vitest/ui@3.2.7)(terser@5.48.0)
       vitest-mock-extended:
         specifier: ^1.3.2
-        version: 1.3.2(typescript@5.9.3)(vitest@3.2.7)
+        version: 1.3.2(@typescript/typescript6@6.0.2)(vitest@3.2.7)
 
 packages:
 
@@ -1412,6 +1415,130 @@ packages:
   '@typescript-eslint/visitor-keys@8.62.1':
     resolution: {integrity: sha512-4g3BLxfdTMy8iZG0MaBkadnlRrCJ74cQiFbyEVMrkwIoqdyaXXQM22cotDvrl4x28wgIZ9rEJRoM+mmhSJpJ1g==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    resolution: {integrity: sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    resolution: {integrity: sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    resolution: {integrity: sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    resolution: {integrity: sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    resolution: {integrity: sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    resolution: {integrity: sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    resolution: {integrity: sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    resolution: {integrity: sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    resolution: {integrity: sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    resolution: {integrity: sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    resolution: {integrity: sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    resolution: {integrity: sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    resolution: {integrity: sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    resolution: {integrity: sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    resolution: {integrity: sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    resolution: {integrity: sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    resolution: {integrity: sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [win32]
+
+  '@typescript/typescript6@6.0.2':
+    resolution: {integrity: sha512-mbCddXd+jm7hfx7w2YU64/Av4/NqqeG3GoRZgxPcgoTxYjhrcfJRw9ULch71SS4G+Q3bOXFhRvPqjguN0Hyp5w==}
+    hasBin: true
 
   '@vitest/coverage-v8@3.2.7':
     resolution: {integrity: sha512-NEGWJS2XNu2PfRLQwOO3CTKj1tTETxNBdk454vDxVBhxJYhPaA/eS0nAI0c+1El1P7a60z8+i+ZrQoGESweGKg==}
@@ -3894,6 +4021,16 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  typescript@7.0.2:
+    resolution: {integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==}
+    engines: {node: '>=16.20.0'}
+    hasBin: true
+
   uid@2.0.2:
     resolution: {integrity: sha512-u3xV3X7uzvi5b1MncmZo3i2Aw222Zk1keqLA1YkHldREkAhAqi65wuPfe7lHx8H/Wzy+8CE7S7uS3jekIM5s8g==}
     engines: {node: '>=8'}
@@ -5126,40 +5263,40 @@ snapshots:
 
   '@types/triple-beam@1.3.5': {}
 
-  '@typescript-eslint/eslint-plugin@8.62.1(@typescript-eslint/parser@8.62.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.62.1(@typescript-eslint/parser@8.62.1(@typescript/typescript6@6.0.2)(eslint@9.39.4))(@typescript/typescript6@6.0.2)(eslint@9.39.4)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.62.1(eslint@9.39.4)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.62.1(@typescript/typescript6@6.0.2)(eslint@9.39.4)
       '@typescript-eslint/scope-manager': 8.62.1
-      '@typescript-eslint/type-utils': 8.62.1(eslint@9.39.4)(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.62.1(eslint@9.39.4)(typescript@5.9.3)
+      '@typescript-eslint/type-utils': 8.62.1(@typescript/typescript6@6.0.2)(eslint@9.39.4)
+      '@typescript-eslint/utils': 8.62.1(@typescript/typescript6@6.0.2)(eslint@9.39.4)
       '@typescript-eslint/visitor-keys': 8.62.1
       eslint: 9.39.4
       ignore: 7.0.5
       natural-compare: 1.4.0
-      ts-api-utils: 2.5.0(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-api-utils: 2.5.0(@typescript/typescript6@6.0.2)
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.62.1(eslint@9.39.4)(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.62.1(@typescript/typescript6@6.0.2)(eslint@9.39.4)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.62.1
       '@typescript-eslint/types': 8.62.1
-      '@typescript-eslint/typescript-estree': 8.62.1(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.62.1(@typescript/typescript6@6.0.2)
       '@typescript-eslint/visitor-keys': 8.62.1
       debug: 4.4.3
       eslint: 9.39.4
-      typescript: 5.9.3
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.62.1(typescript@5.9.3)':
+  '@typescript-eslint/project-service@8.62.1(@typescript/typescript6@6.0.2)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.62.1(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.62.1(@typescript/typescript6@6.0.2)
       '@typescript-eslint/types': 8.62.1
       debug: 4.4.3
-      typescript: 5.9.3
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - supports-color
 
@@ -5168,47 +5305,47 @@ snapshots:
       '@typescript-eslint/types': 8.62.1
       '@typescript-eslint/visitor-keys': 8.62.1
 
-  '@typescript-eslint/tsconfig-utils@8.62.1(typescript@5.9.3)':
+  '@typescript-eslint/tsconfig-utils@8.62.1(@typescript/typescript6@6.0.2)':
     dependencies:
-      typescript: 5.9.3
+      typescript: '@typescript/typescript6@6.0.2'
 
-  '@typescript-eslint/type-utils@8.62.1(eslint@9.39.4)(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.62.1(@typescript/typescript6@6.0.2)(eslint@9.39.4)':
     dependencies:
       '@typescript-eslint/types': 8.62.1
-      '@typescript-eslint/typescript-estree': 8.62.1(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.62.1(eslint@9.39.4)(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.62.1(@typescript/typescript6@6.0.2)
+      '@typescript-eslint/utils': 8.62.1(@typescript/typescript6@6.0.2)(eslint@9.39.4)
       debug: 4.4.3
       eslint: 9.39.4
-      ts-api-utils: 2.5.0(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-api-utils: 2.5.0(@typescript/typescript6@6.0.2)
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - supports-color
 
   '@typescript-eslint/types@8.62.1': {}
 
-  '@typescript-eslint/typescript-estree@8.62.1(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@8.62.1(@typescript/typescript6@6.0.2)':
     dependencies:
-      '@typescript-eslint/project-service': 8.62.1(typescript@5.9.3)
-      '@typescript-eslint/tsconfig-utils': 8.62.1(typescript@5.9.3)
+      '@typescript-eslint/project-service': 8.62.1(@typescript/typescript6@6.0.2)
+      '@typescript-eslint/tsconfig-utils': 8.62.1(@typescript/typescript6@6.0.2)
       '@typescript-eslint/types': 8.62.1
       '@typescript-eslint/visitor-keys': 8.62.1
       debug: 4.4.3
       minimatch: 10.2.5
       semver: 7.8.5
       tinyglobby: 0.2.17
-      ts-api-utils: 2.5.0(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-api-utils: 2.5.0(@typescript/typescript6@6.0.2)
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.62.1(eslint@9.39.4)(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.62.1(@typescript/typescript6@6.0.2)(eslint@9.39.4)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4)
       '@typescript-eslint/scope-manager': 8.62.1
       '@typescript-eslint/types': 8.62.1
-      '@typescript-eslint/typescript-estree': 8.62.1(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.62.1(@typescript/typescript6@6.0.2)
       eslint: 9.39.4
-      typescript: 5.9.3
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - supports-color
 
@@ -5216,6 +5353,70 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.62.1
       eslint-visitor-keys: 5.0.1
+
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript6@6.0.2':
+    dependencies:
+      '@typescript/old': typescript@6.0.3
 
   '@vitest/coverage-v8@3.2.7(vitest@3.2.7)':
     dependencies:
@@ -5236,14 +5437,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/eslint-plugin@1.6.21(@typescript-eslint/eslint-plugin@8.62.1(@typescript-eslint/parser@8.62.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3)(vitest@3.2.7)':
+  '@vitest/eslint-plugin@1.6.21(@typescript-eslint/eslint-plugin@8.62.1(@typescript-eslint/parser@8.62.1(@typescript/typescript6@6.0.2)(eslint@9.39.4))(@typescript/typescript6@6.0.2)(eslint@9.39.4))(@typescript/typescript6@6.0.2)(eslint@9.39.4)(vitest@3.2.7)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.62.1
-      '@typescript-eslint/utils': 8.62.1(eslint@9.39.4)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.62.1(@typescript/typescript6@6.0.2)(eslint@9.39.4)
       eslint: 9.39.4
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 8.62.1(@typescript-eslint/parser@8.62.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3)
-      typescript: 5.9.3
+      '@typescript-eslint/eslint-plugin': 8.62.1(@typescript-eslint/parser@8.62.1(@typescript/typescript6@6.0.2)(eslint@9.39.4))(@typescript/typescript6@6.0.2)(eslint@9.39.4)
+      typescript: '@typescript/typescript6@6.0.2'
       vitest: 3.2.7(@types/node@22.20.0)(@vitest/ui@3.2.7)(terser@5.48.0)
     transitivePeerDependencies:
       - supports-color
@@ -6126,11 +6327,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.13.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4):
+  eslint-module-utils@2.13.0(@typescript-eslint/parser@8.62.1(@typescript/typescript6@6.0.2)(eslint@9.39.4))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.62.1(eslint@9.39.4)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.62.1(@typescript/typescript6@6.0.2)(eslint@9.39.4)
       eslint: 9.39.4
       eslint-import-resolver-node: 0.3.10
     transitivePeerDependencies:
@@ -6142,7 +6343,7 @@ snapshots:
       eslint-utils: 2.1.0
       regexpp: 3.2.0
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(@typescript/typescript6@6.0.2)(eslint@9.39.4))(eslint@9.39.4):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -6153,7 +6354,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.13.0(@typescript-eslint/parser@8.62.1(eslint@9.39.4)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4)
+      eslint-module-utils: 2.13.0(@typescript-eslint/parser@8.62.1(@typescript/typescript6@6.0.2)(eslint@9.39.4))(eslint-import-resolver-node@0.3.10)(eslint@9.39.4)
       hasown: 2.0.4
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -6165,7 +6366,7 @@ snapshots:
       string.prototype.trimend: 1.0.10
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.62.1(eslint@9.39.4)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.62.1(@typescript/typescript6@6.0.2)(eslint@9.39.4)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -7825,25 +8026,25 @@ snapshots:
 
   triple-beam@1.4.1: {}
 
-  ts-api-utils@2.5.0(typescript@5.9.3):
+  ts-api-utils@2.5.0(@typescript/typescript6@6.0.2):
     dependencies:
-      typescript: 5.9.3
+      typescript: '@typescript/typescript6@6.0.2'
 
-  ts-essentials@10.2.1(typescript@5.9.3):
+  ts-essentials@10.2.1(@typescript/typescript6@6.0.2):
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: '@typescript/typescript6@6.0.2'
 
-  ts-loader@9.6.2(typescript@5.9.3)(webpack@5.106.2(@swc/core@1.15.43)):
+  ts-loader@9.6.2(@typescript/typescript6@6.0.2)(webpack@5.106.2(@swc/core@1.15.43)):
     dependencies:
       chalk: 4.1.2
       picomatch: 4.0.4
       source-map: 0.7.6
-      typescript: 5.9.3
+      typescript: '@typescript/typescript6@6.0.2'
       webpack: 5.106.2(@swc/core@1.15.43)
 
-  tsconfck@3.1.6(typescript@5.9.3):
+  tsconfck@3.1.6(@typescript/typescript6@6.0.2):
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: '@typescript/typescript6@6.0.2'
 
   tsconfig-paths-webpack-plugin@4.2.0:
     dependencies:
@@ -7917,6 +8118,31 @@ snapshots:
       reflect.getprototypeof: 1.0.10
 
   typescript@5.9.3: {}
+
+  typescript@6.0.3: {}
+
+  typescript@7.0.2:
+    optionalDependencies:
+      '@typescript/typescript-aix-ppc64': 7.0.2
+      '@typescript/typescript-darwin-arm64': 7.0.2
+      '@typescript/typescript-darwin-x64': 7.0.2
+      '@typescript/typescript-freebsd-arm64': 7.0.2
+      '@typescript/typescript-freebsd-x64': 7.0.2
+      '@typescript/typescript-linux-arm': 7.0.2
+      '@typescript/typescript-linux-arm64': 7.0.2
+      '@typescript/typescript-linux-loong64': 7.0.2
+      '@typescript/typescript-linux-mips64el': 7.0.2
+      '@typescript/typescript-linux-ppc64': 7.0.2
+      '@typescript/typescript-linux-riscv64': 7.0.2
+      '@typescript/typescript-linux-s390x': 7.0.2
+      '@typescript/typescript-linux-x64': 7.0.2
+      '@typescript/typescript-netbsd-arm64': 7.0.2
+      '@typescript/typescript-netbsd-x64': 7.0.2
+      '@typescript/typescript-openbsd-arm64': 7.0.2
+      '@typescript/typescript-openbsd-x64': 7.0.2
+      '@typescript/typescript-sunos-x64': 7.0.2
+      '@typescript/typescript-win32-arm64': 7.0.2
+      '@typescript/typescript-win32-x64': 7.0.2
 
   uid@2.0.2:
     dependencies:
@@ -7997,11 +8223,11 @@ snapshots:
       - supports-color
       - terser
 
-  vite-tsconfig-paths@5.1.4(typescript@5.9.3)(vite@5.4.21(@types/node@22.20.0)(terser@5.48.0)):
+  vite-tsconfig-paths@5.1.4(@typescript/typescript6@6.0.2)(vite@5.4.21(@types/node@22.20.0)(terser@5.48.0)):
     dependencies:
       debug: 4.4.3
       globrex: 0.1.2
-      tsconfck: 3.1.6(typescript@5.9.3)
+      tsconfck: 3.1.6(@typescript/typescript6@6.0.2)
     optionalDependencies:
       vite: 5.4.21(@types/node@22.20.0)(terser@5.48.0)
     transitivePeerDependencies:
@@ -8018,10 +8244,10 @@ snapshots:
       fsevents: 2.3.3
       terser: 5.48.0
 
-  vitest-mock-extended@1.3.2(typescript@5.9.3)(vitest@3.2.7):
+  vitest-mock-extended@1.3.2(@typescript/typescript6@6.0.2)(vitest@3.2.7):
     dependencies:
-      ts-essentials: 10.2.1(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-essentials: 10.2.1(@typescript/typescript6@6.0.2)
+      typescript: '@typescript/typescript6@6.0.2'
       vitest: 3.2.7(@types/node@22.20.0)(@vitest/ui@3.2.7)(terser@5.48.0)
 
   vitest@3.2.7(@types/node@22.20.0)(@vitest/ui@3.2.7)(terser@5.48.0):

--- a/src/hocuspocus/extensions/authorization/alkemio-authorizer/alkemio.authorizer.spec.ts
+++ b/src/hocuspocus/extensions/authorization/alkemio-authorizer/alkemio.authorizer.spec.ts
@@ -409,7 +409,9 @@ describe('AlkemioAuthorizer', () => {
         (authorizer as any).connected = connectedSpy;
 
         // Act & Assert
-        await expect(authorizer.onConnect(mockOnConnectData)).rejects.toThrow('Authorization failed');
+        await expect(authorizer.onConnect(mockOnConnectData)).rejects.toThrow(
+          'Authorization failed'
+        );
         expect(connectedSpy).not.toHaveBeenCalled();
       });
     });

--- a/src/hocuspocus/extensions/storage/alkemio-storage/alkemio.storage.spec.ts
+++ b/src/hocuspocus/extensions/storage/alkemio-storage/alkemio.storage.spec.ts
@@ -25,8 +25,8 @@ describe('AlkemioStorage', () => {
         },
       ],
     })
-        .useMocker(defaultMockerFactory)
-        .compile();
+      .useMocker(defaultMockerFactory)
+      .compile();
 
     storage = module.get<AlkemioStorage>(AlkemioStorage);
   });

--- a/src/hocuspocus/extensions/storage/alkemio-storage/alkemio.storage.ts
+++ b/src/hocuspocus/extensions/storage/alkemio-storage/alkemio.storage.ts
@@ -26,9 +26,7 @@ export class AlkemioStorage extends AbstractStorage {
    * Called after onAuthenticate
    * @throws if the document cannot be loaded
    */
-  public async onLoadDocument({
-    documentName: documentId,
-  }: onLoadDocumentPayload): Promise<Doc> {
+  public async onLoadDocument({ documentName: documentId }: onLoadDocumentPayload): Promise<Doc> {
     try {
       return await this.storageService.loadDocument(documentId);
     } catch (error: any) {

--- a/src/hocuspocus/hocuspocus.server.spec.ts
+++ b/src/hocuspocus/hocuspocus.server.spec.ts
@@ -3,8 +3,14 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { mock, MockProxy } from 'vitest-mock-extended';
 import { ConfigService } from '@nestjs/config';
 import { HocuspocusServer } from './hocuspocus.server';
-import { AlkemioAuthenticator, ALKEMIO_AUTHENTICATION_EXTENSION } from './extensions/authentication/alkemio-authenticator';
-import { AlkemioAuthorizer, ALKEMIO_AUTHORIZATION_EXTENSION } from './extensions/authorization/alkemio-authorizer';
+import {
+  AlkemioAuthenticator,
+  ALKEMIO_AUTHENTICATION_EXTENSION,
+} from './extensions/authentication/alkemio-authenticator';
+import {
+  AlkemioAuthorizer,
+  ALKEMIO_AUTHORIZATION_EXTENSION,
+} from './extensions/authorization/alkemio-authorizer';
 import { AlkemioStorage, ALKEMIO_STORAGE_EXTENSION } from './extensions/storage/alkemio-storage';
 import { NorthStarMetric, NORTH_STAR_METRIC_EXTENSION } from './extensions/north-star-metric';
 import { Server, Hocuspocus } from '@hocuspocus/server';
@@ -83,7 +89,9 @@ describe('HocuspocusServer', () => {
       await service.onModuleInit();
 
       // Assert
-      expect(mockConfigService.get).toHaveBeenCalledWith('settings.application.ws_port', { infer: true });
+      expect(mockConfigService.get).toHaveBeenCalledWith('settings.application.ws_port', {
+        infer: true,
+      });
       expect(service.getServer().configuration.port).toEqual(expectedPort);
     });
   });
@@ -123,4 +131,3 @@ describe('HocuspocusServer', () => {
     });
   });
 });
-

--- a/src/hocuspocus/hocuspocus.server.ts
+++ b/src/hocuspocus/hocuspocus.server.ts
@@ -13,7 +13,10 @@ import {
   ALKEMIO_STORAGE_EXTENSION,
   AlkemioStorage,
 } from '@src/hocuspocus/extensions/storage/alkemio-storage';
-import { NorthStarMetric, NORTH_STAR_METRIC_EXTENSION } from '@src/hocuspocus/extensions/north-star-metric';
+import {
+  NorthStarMetric,
+  NORTH_STAR_METRIC_EXTENSION,
+} from '@src/hocuspocus/extensions/north-star-metric';
 import { ConfigType } from '../config';
 import { sortExtensions } from './sort.extensions';
 

--- a/src/hocuspocus/sort.extensions.ts
+++ b/src/hocuspocus/sort.extensions.ts
@@ -1,4 +1,4 @@
-import { Extension } from "@hocuspocus/server";
+import { Extension } from '@hocuspocus/server';
 
 /**
  * Assigns a sort order to extensions based on their order in the array,

--- a/src/services/integration/client-proxy.factory.spec.ts
+++ b/src/services/integration/client-proxy.factory.spec.ts
@@ -122,9 +122,10 @@ describe('clientProxyFactory', () => {
       expect(ClientProxyFactory.create).toHaveBeenCalledWith(
         expect.objectContaining({
           options: expect.objectContaining({
-          urls: [expect.objectContaining({ heartbeat: 180 })], // 3x the configured value
-        }),
-      }));
+            urls: [expect.objectContaining({ heartbeat: 180 })], // 3x the configured value
+          }),
+        })
+      );
     });
   });
 

--- a/src/services/integration/integration.service.ts
+++ b/src/services/integration/integration.service.ts
@@ -5,17 +5,8 @@ import { ConfigService } from '@nestjs/config';
 import { LogContext } from '@common/enums';
 import { ConfigType } from '@src/config';
 import { NotInitializedException } from '@common/exceptions';
-import {
-  IntegrationEventPattern,
-  IntegrationMessagePattern,
-  RMQConnectionError,
-} from './types';
-import {
-  FetchInputData,
-  InfoInputData,
-  SaveInputData,
-  MemoContributionsInputData,
-} from './inputs';
+import { IntegrationEventPattern, IntegrationMessagePattern, RMQConnectionError } from './types';
+import { FetchInputData, InfoInputData, SaveInputData, MemoContributionsInputData } from './inputs';
 import {
   FetchErrorCodes,
   FetchErrorData,

--- a/src/services/integration/sender.service.spec.ts
+++ b/src/services/integration/sender.service.spec.ts
@@ -91,7 +91,7 @@ describe('SenderService', () => {
         timeoutMs: 1000,
         maxRetries: 0,
       })
-    ).rejects.toThrow('\'undefined\' error caught while processing integration request.');
+    ).rejects.toThrow("'undefined' error caught while processing integration request.");
   });
 
   it('should handle null errors and throw an appropriate message', async () => {
@@ -103,7 +103,7 @@ describe('SenderService', () => {
         timeoutMs: 1000,
         maxRetries: 0,
       })
-    ).rejects.toThrow('\'null\' error caught while processing integration request.');
+    ).rejects.toThrow("'null' error caught while processing integration request.");
   });
 
   it('should handle unknown error types and throw an appropriate message', async () => {

--- a/src/services/util/transform/doc.to.binary.state.v2.spec.ts
+++ b/src/services/util/transform/doc.to.binary.state.v2.spec.ts
@@ -176,4 +176,3 @@ describe('yjsDocToBinaryStateV2', () => {
     });
   });
 });
-

--- a/src/services/util/transform/index.ts
+++ b/src/services/util/transform/index.ts
@@ -1,2 +1,2 @@
-export * from "./binary.state.v2.to.doc";
-export * from "./doc.to.binary.state.v2";
+export * from './binary.state.v2.to.doc';
+export * from './doc.to.binary.state.v2';

--- a/src/services/util/util.service.spec.ts
+++ b/src/services/util/util.service.spec.ts
@@ -8,7 +8,15 @@ import { IntegrationService } from '../integration';
 import { LogContext } from '@common/enums';
 import { FetchException } from './fetch.exception';
 import { FetchInputData, InfoInputData, SaveInputData } from '../integration/inputs';
-import { InfoOutputData, FetchOutputData, FetchContentData, FetchErrorData, FetchErrorCodes, SaveOutputData, SaveContentData } from '../integration/outputs';
+import {
+  InfoOutputData,
+  FetchOutputData,
+  FetchContentData,
+  FetchErrorData,
+  FetchErrorCodes,
+  SaveOutputData,
+  SaveContentData,
+} from '../integration/outputs';
 import * as transformModule from './transform';
 
 // Mock the transform module
@@ -55,16 +63,14 @@ describe('UtilService', () => {
     describe('failing paths', () => {
       it('should return default InfoOutputData when integrationService.info throws an error', async () => {
         // Arrange
-        const error = new Error('Integration service error')
+        const error = new Error('Integration service error');
         mockIntegrationService.info.mockRejectedValue(error);
 
         // Act
         const result = await service.getUserAccessToMemo(userId, memoId);
 
         // Assert
-        expect(mockIntegrationService.info).toHaveBeenCalledWith(
-          new InfoInputData(userId, memoId)
-        );
+        expect(mockIntegrationService.info).toHaveBeenCalledWith(new InfoInputData(userId, memoId));
         expect(mockLogger.error).toHaveBeenCalledWith(
           {
             message: 'Received error while getting user access to Memo',
@@ -111,9 +117,7 @@ describe('UtilService', () => {
         const result = await service.getUserAccessToMemo(userId, memoId);
 
         // Assert
-        expect(mockIntegrationService.info).toHaveBeenCalledWith(
-          new InfoInputData(userId, memoId)
-        );
+        expect(mockIntegrationService.info).toHaveBeenCalledWith(new InfoInputData(userId, memoId));
         expect(result).toEqual(expectedResult);
       });
     });
@@ -157,9 +161,7 @@ describe('UtilService', () => {
         await expect(service.fetchMemo(documentId)).rejects.toThrow(FetchException);
         await expect(service.fetchMemo(documentId)).rejects.toThrow('Failed to fetch memo');
 
-        expect(mockIntegrationService.fetch).toHaveBeenCalledWith(
-          new FetchInputData(documentId)
-        );
+        expect(mockIntegrationService.fetch).toHaveBeenCalledWith(new FetchInputData(documentId));
       });
     });
 
@@ -179,9 +181,7 @@ describe('UtilService', () => {
         const result = await service.fetchMemo(documentId);
 
         // Assert
-        expect(mockIntegrationService.fetch).toHaveBeenCalledWith(
-          new FetchInputData(documentId)
-        );
+        expect(mockIntegrationService.fetch).toHaveBeenCalledWith(new FetchInputData(documentId));
         expect(transformModule.binaryStateV2ToYjsDoc).toHaveBeenCalledWith(expectedBuffer);
         expect(result).toBe(mockDoc);
       });

--- a/test/mocks/winston.provider.mock.ts
+++ b/test/mocks/winston.provider.mock.ts
@@ -1,6 +1,6 @@
 import { vi } from 'vitest';
 import { WINSTON_MODULE_NEST_PROVIDER, WinstonLogger } from 'nest-winston';
-import { MockValueProvider } from "@test/utils";
+import { MockValueProvider } from '@test/utils';
 
 export const MockWinstonProvider: MockValueProvider<WinstonLogger> = {
   provide: WINSTON_MODULE_NEST_PROVIDER,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "compilerOptions": {
-    "baseUrl": ".",
     "module": "esnext",
     "target": "esnext",
     "moduleResolution": "Bundler",
@@ -17,10 +16,11 @@
     "skipLibCheck": true,
     "resolveJsonModule": true,
     "declaration": true,
+    "types": ["node"],
     "paths": {
-      "@src/*": ["src/*"],
-      "@test/*": ["test/*"],
-      "@common/*": ["src/common/*"]
+      "@src/*": ["./src/*"],
+      "@test/*": ["./test/*"],
+      "@common/*": ["./src/common/*"]
     },
   },
   "exclude": ["node_modules", "dist"]

--- a/tsconfig.prod.json
+++ b/tsconfig.prod.json
@@ -1,5 +1,8 @@
 {
   "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src"
+  },
   "include": ["src"],
   "exclude": ["node_modules", "dist", "**/*.spec.ts", "**/*.test.ts"]
 }


### PR DESCRIPTION
## TypeScript 7 upgrade — collaborative-document-service slice (workspace#019-typescript-7-upgrade)

Dual-compiler adoption; native7 typecheck gate; ts-loader/webpack emit stays on the JS line; docker build green.

Part of the cross-repo TypeScript 7 (native `tsgo`) upgrade. This repo builds, typechecks (native), lints, and passes its test gates on the dual-compiler layout. See the workspace spec for the fleet-wide playbook and rationale.

---
### Forge evidence digest — `workspace#019-typescript-7-upgrade`
- **Spec / plan / tasks**: `agents-hq/specs/019-typescript-7-upgrade/` (spec.md, plan.md, research/tsgo-playbook.md, per-repo tasks). Board story: alkem-io/alkemio#1799.
- **Architecture**: Fable chief synthesizing a 2-seat Opus council (simplifier seat failed structured output — recorded). Operator dissent on the mandatory-tsgo-floor overruled by operator intake ruling, mechanized as risk R-3.
- **Live verification**: PASS — gql-live 588/588, test-suites configuration suite green, US2 acceptance walk (health, unauth metadata, real admin login, home dashboard on the TS7 bundle) all green; 11/11 risk-register entries mitigated. Durable spec persisted: `test-suites .../ts7-platform-smoke.spec.ts`.
- **Review**: Opus panel × 4 dimensions (correctness, spec-compliance, quality, SOC 2/ISO 27001 security), two-lens adversarial verify. 4 confirmed findings across the feature: 3 fixed (notifications emit ×2, ecosystem-analytics supply-chain scoping), 1 declined (client-web `build:dev --mode` — mandated by plan.md for the acceptance walk).
- **Security**: the run's `security-hold` was triggered **only by pre-existing findings on `develop`**, none introduced by this toolchain change — filed for their owners: cds gateway-header auth (collaborative-document-service#104), organisation static-credential gate (organisation#120), ecosystem-analytics image-proxy SSRF (ecosystem-analytics#115, HIGH) + committed AES key (ecosystem-analytics#116). Operator accepted shipping the clean TS7 change alongside this tracked debt; the HIGH SSRF is getting a separate hotfix PR.
- **Compiler model**: TS 7 native (`tsgo`) as the typecheck gate; the JS-API line (`@typescript/typescript6` 6.0.2, aliased) remains ship-authoritative for emit/test/lint until the TS 7.1 Compiler API lands. Native typecheck speedups measured 7.7–8.5×.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an additional TypeScript validation step to the automated test pipeline.
  * Improved container and package setup to better support installs in slower or higher-latency environments.

* **Bug Fixes**
  * Updated project configuration to make TypeScript path resolution more reliable.
  * Adjusted build settings so dependency installation works more consistently in Docker-based builds.

* **Chores**
  * Refined linting and test formatting rules.
  * Updated production and development TypeScript settings for clearer build behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->