### PR TITLE
chore: update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/build-deploy-k8s-dev-hetzner.yml
+++ b/.github/workflows/build-deploy-k8s-dev-hetzner.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout GitHub Action'
-        uses: actions/checkout@v4.3.1
+        uses: actions/checkout@v7
 
       - name: 'Login into ACR'
         uses: azure/docker-login@v2
@@ -28,10 +28,10 @@ jobs:
     needs: build
     steps:
       - name: 'Checkout GitHub Action'
-        uses: actions/checkout@v4.3.1
+        uses: actions/checkout@v7
 
       - name: Install Kubectl
-        uses: azure/setup-kubectl@v4.0.1
+        uses: azure/setup-kubectl@v5.1.0
         with:
           version: 'v1.27.6' # Ensure this matches the version used in your cluster
 
@@ -49,7 +49,7 @@ jobs:
             --docker-password=${{ secrets.REGISTRY_PASSWORD }} \
             --dry-run=client -o yaml | kubectl apply -f -
 
-      - uses: Azure/k8s-deploy@v5.1.0
+      - uses: Azure/k8s-deploy@v7.0.0
         with:
           manifests: |
             manifests/collaborative-document-service-deployment-dev.yaml

--- a/.github/workflows/build-deploy-k8s-sandbox-hetzner.yml
+++ b/.github/workflows/build-deploy-k8s-sandbox-hetzner.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout GitHub Action'
-        uses: actions/checkout@v4.3.1
+        uses: actions/checkout@v7
 
       - name: 'Login into ACR'
         uses: azure/docker-login@v2
@@ -27,10 +27,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout GitHub Action'
-        uses: actions/checkout@v4.3.1
+        uses: actions/checkout@v7
 
       - name: Install Kubectl
-        uses: azure/setup-kubectl@v4.0.1
+        uses: azure/setup-kubectl@v5.1.0
         with:
           version: 'v1.27.6' # Ensure this matches the version used in your cluster
 
@@ -49,7 +49,7 @@ jobs:
             --dry-run=client -o yaml | kubectl apply -f -
 
       - name: Deploy to k8s on Hetzner
-        uses: azure/k8s-deploy@v5.1.0
+        uses: azure/k8s-deploy@v7.0.0
         with:
           manifests: |
             manifests/collaborative-document-service-deployment-dev.yaml

--- a/.github/workflows/build-deploy-k8s-test-hetzner.yml
+++ b/.github/workflows/build-deploy-k8s-test-hetzner.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout GitHub Action'
-        uses: actions/checkout@v4.3.1
+        uses: actions/checkout@v7
 
       - name: 'Login into ACR'
         uses: azure/docker-login@v2
@@ -27,10 +27,10 @@ jobs:
     needs: build
     steps:
       - name: 'Checkout GitHub Action'
-        uses: actions/checkout@v4.3.1
+        uses: actions/checkout@v7
 
       - name: Install Kubectl
-        uses: azure/setup-kubectl@v4.0.1
+        uses: azure/setup-kubectl@v5.1.0
         with:
           version: 'v1.27.6' # Ensure this matches the version used in your cluster
 
@@ -48,7 +48,7 @@ jobs:
             --docker-password=${{ secrets.REGISTRY_PASSWORD }} \
             --dry-run=client -o yaml | kubectl apply -f -
 
-      - uses: Azure/k8s-deploy@v5.1.0
+      - uses: Azure/k8s-deploy@v7.0.0
         with:
           manifests: |
             manifests/collaborative-document-service-deployment-dev.yaml

--- a/.github/workflows/build-release-docker-hub.yml
+++ b/.github/workflows/build-release-docker-hub.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.6.0
+        uses: actions/checkout@v7
       - name: Prepare
         id: prep
         run: |
@@ -39,18 +39,18 @@ jobs:
           echo "tags=${TAGS}" >> $GITHUB_OUTPUT
           echo "created={$(date -u +'%Y-%m-%dT%H:%M:%SZ')}" >> $GITHUB_OUTPUT
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3.7.0
+        uses: docker/setup-qemu-action@v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.12.0
+        uses: docker/setup-buildx-action@v4
       - name: Login to DockerHub
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3.7.0
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v5.4.0
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v4
 
       - name: Setup Node.js
         uses: actions/setup-node@v7

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -11,13 +11,13 @@ jobs:
     runs-on: arc-runner-set
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6.4.0
+        uses: actions/setup-node@v7
         with:
           node-version: '22.23.1'
           cache: 'pnpm'

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v4
 
       - name: Setup Node.js
         uses: actions/setup-node@v7

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -11,13 +11,13 @@ jobs:
     runs-on: arc-runner-set
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6.4.0
+        uses: actions/setup-node@v7
         with:
           node-version: '22.23.1'
           cache: 'pnpm'


### PR DESCRIPTION
Bump GitHub Actions to latest releases (org-wide actions audit, 2026-07-21).

| Action | Old | New |
|---|---|---|
| `Azure/k8s-deploy` | v5.1.0 | v7.0.0 |
| `actions/checkout` | v3.6.0 v4.3.1 v6 | v7 |
| `actions/setup-node` | v6.4.0 | v7 |
| `azure/k8s-deploy` | v5.1.0 | v7.0.0 |
| `azure/setup-kubectl` | v4.0.1 | v5.1.0 |
| `docker/build-push-action` | v5.4.0 | v7 |
| `docker/login-action` | v3.7.0 | v4 |
| `docker/setup-buildx-action` | v3.12.0 | v4 |
| `docker/setup-qemu-action` | v3.7.0 | v4 |
| `pnpm/action-setup` | v4 | v6 |

Compatibility: all `with:` inputs validated against each action's schema at the target version; bumped actions run on node24 (GitHub-hosted runners OK).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
