### PR TITLE
0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "collaborative-document-service",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Backend microservice, supporting real-time multi-user collaboration on a shared document.",
   "author": "Alkemio Foundation",
   "license": "EUPL-1.2",


### PR DESCRIPTION
Version bump ahead of the `develop → main` promotion and the v0.5.0 release.

Carries the distroless runtime migration (#122, workspace#036) and the 019 TypeScript 7 upgrade (#105), plus dependency updates.

Minor rather than major: the TS7 change adds a `typecheck:native` **gate**; the swc emit path and its TS 6.0 typecheck fork are unchanged (`build` is byte-identical on both branches). No runtime behaviour change.

Note: `package.json` read 0.4.0 on both `develop` and `main` while v0.4.0 was already published — the previous release was tagged from a merge commit without a bump. This restores the invariant that the file matches the released tag.

Refs: epic alkem-io/infrastructure-operations#2499